### PR TITLE
Update README to clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Currently the data output is in the [bulk format](https://www.elastic.co/guide/e
 
 ## Install
 
-Reqires [Glide](https://glide.sh).
+Requires
+
+* [Glide](https://glide.sh)
+* Go >=1.5 with `GO15VENDOREXPERIMENT=1`
 
 ```
-git clone https://github.com/chop-dbhi/sqltojson.git
-glide install
-make install
+git clone https://github.com/chop-dbhi/sqltojson.git && cd sqltojson
+glide -y glide.lock install
+make build
 ```
 
 ## Config


### PR DESCRIPTION
Updated the readme with some clarification to the instructions. I'm not very familiar with glide, but it looks like you have to specify a file if `glide.yaml` is not present (maybe this is only in the later versions? im on glide version 0.11.0-dev). 

Also changed the make target to `build` as `install` does not exist. 
