### PR TITLE
Per discussion in #2. Include install target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,8 @@ dist:
         -output="./dist/{{.OS}}/{{.Arch}}/$(PROG_NAME)" \
 		./cmd/sqltojson
 
+install:
+	export GO15VENDOREXPERIMENT=1
+	glide install
+
 .PHONY: dist


### PR DESCRIPTION
Includes an install target which sets the appropriate environment variable to allow glide package management and runs the glide install command.

Signed-off-by: Tyler Rivera tyler.rivera@gmail.com
